### PR TITLE
3DS: Fixed unnecessary file resize and failed to open extdata when success

### DIFF
--- a/3DS/FsLib/source/file.cpp
+++ b/3DS/FsLib/source/file.cpp
@@ -295,7 +295,7 @@ bool fslib::File::resizeIfNeeded(size_t bufferSize)
     size_t spaceRemaining = m_fileSize - m_offset;
 
     // Everything is fine.
-    if (spaceRemaining >= m_fileSize)
+    if (spaceRemaining >= bufferSize)
     {
         return true;
     }

--- a/3DS/FsLib/source/saveDataArchive.cpp
+++ b/3DS/FsLib/source/saveDataArchive.cpp
@@ -35,7 +35,7 @@ bool fslib::openExtData(std::u16string_view deviceName, uint32_t extDataID)
         return false;
     }
 
-    if (fslib::mapArchiveToDevice(deviceName, archive))
+    if (!fslib::mapArchiveToDevice(deviceName, archive))
     {
         FSUSER_CloseArchive(archive);
         return false;


### PR DESCRIPTION
As title says, it fixes two small errors in the code in functions openExtData and resizeIfNecessary